### PR TITLE
Remove old reference to Zen Columns.

### DIFF
--- a/stylesheets/_zen.scss
+++ b/stylesheets/_zen.scss
@@ -1,3 +1,3 @@
-// Import the partial for Zen Grids, but not for Zen Columns.
+// Import the partial for Zen Grids.
 
 @import "zen/grids";


### PR DESCRIPTION
The comment in stylesheets/_zen.scss still referes to Zen Columns, which no longer seem to exist.
