### PR TITLE
Provide overflow safe clearfix.

### DIFF
--- a/stylesheets/zen/_grids.scss
+++ b/stylesheets/zen/_grids.scss
@@ -49,6 +49,9 @@ $zen-float-direction: left !default;
 // This is a helper variable for RTL layouts.
 $zen-reverse-all-floats: false !default;
 
+// Set this to true if grid containers need to allow overflowing content.
+$zen-clearfix-with-overflow: false !default;
+
 
 //
 // Zen Grids requires the clearfix mixin.
@@ -57,11 +60,34 @@ $zen-reverse-all-floats: false !default;
 
 
 //
+// Zen Grids supports two clearfix methods for the grid container. The default
+// sets overflow to hidden. If you have child elements that need to extend
+// beyond the grid container, you can set $zen-clearfix-with-overflow to true
+// for an overflow safe clearfix.
+//
+@mixin zen-clearfix ($has-overflow: $zen-clearfix-with-overflow) {
+  @if $has-overflow {
+    &:before,
+    &:after {
+      content: "";
+      display: table;
+    }
+    &:after {
+      clear: both;
+    }
+    *zoom: 1;
+  }
+  @else {
+   @include clearfix;
+  }
+}
+
+//
 // Apply this to the grid container element.
 //
 @mixin zen-grid-container () {
   position: relative;
-  @include clearfix;
+  @include zen-clearfix();
 }
 
 //


### PR DESCRIPTION
Sometimes it is necessary for child elements to extend beyond the boundaries of the grid container. In these cases, the default overflow:hidden clearfix method used by Compass doesn't work. 

This patch adds a $zen-clearfix-with-overflow variable (defaults to false) and a zen-clearfix() mixin. If $zen-clearfix-with-overflow is false, then the default Compass clearfix is used on grid containers. But if it is true, then an overflow safe clearfix method is used. See http://html5boilerplate.com/docs/css/#clearfix- for details on this second clearfix method.
