### PR TITLE
Expand use and function of zen-grid-item-width()

### DIFF
--- a/stylesheets/zen/_grids.scss
+++ b/stylesheets/zen/_grids.scss
@@ -102,8 +102,8 @@ $zen-reverse-all-floats: false !default;
   float: $dir;
   width: zen-grid-item-width($column-span, $column-position, $column-count, $gutter-width, $grid-width, $box-sizing);
   margin: {
-    #{$dir}: ($column-position - 1) * $unit-width;
-    #{$rev}: (1 - $column-position - $column-span) * $unit-width;
+    #{$dir}: zen-grid-item-width(($column-position - 1), 1, $column-count, $gutter-width, $grid-width, border-box);
+    #{$rev}: - zen-grid-item-width(($column-position + $column-span - 1), 1, $column-count, $gutter-width, $grid-width, border-box);
   }
 
   // Auto-apply the unit base mixin.


### PR DESCRIPTION
This branch makes the following changes:
1. The box sizing method check, and corresponding width adjustment, is moved inside the zen-grid-item-width() function itself. 
2. $column-position, $gutter-width and $box-sizing variables are added to the zen-grid-item-width() function's input. The gutter-width and $box-sizing variables are needed for the box sizing method check. The column-position variable is added to enable more advanced features in the future, like grids with variable width columns.
3. zen-grid-item-width()  is now used to calculate the width in the zen-grid-item mixin, as well as the zen-grid-flow-item mixin. It is also used to calculate the margins for grid items. 
4. If zen-grid-item-width() is called without any variables, it will now return the full grid width by default. 

In addition to making the zen-grid-item-width() function more useful in its own right, which may have uses outside of the zen-grid mixins themselves, these updates open the door to more seamless future enhancements. For instance, you can now implement a non-equal grid columns by expanding zen-grid-item-width(), without negatively impacting anyone already using this plugin.
